### PR TITLE
update ImGui::End() to ImGui::EndChild()

### DIFF
--- a/imgui-editor/dependencies/modals/modals.cpp
+++ b/imgui-editor/dependencies/modals/modals.cpp
@@ -47,7 +47,7 @@ void modalManager::Instance()
 			) && ImGui::IsMouseClicked(0) && !ImGui::IsPopupOpen("", ImGuiPopupFlags_AnyPopupId))
 				m_bShow = false;
 		}
-		ImGui::End();
+		ImGui::EndChild();
 	}
 	ImGui::End();
 }


### PR DESCRIPTION
#  change ImGui::End() to ImGui::EndChild()


## **Description**
in modals.cpp 
void modalManager::Instance()

we must use ImGui::EndChild() to match ImGui::BeginChild("MODAL_CONTENT",...)

